### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/wifipumpkin3/core/servers/rest/blueprints/restapi/logger.py
+++ b/wifipumpkin3/core/servers/rest/blueprints/restapi/logger.py
@@ -38,7 +38,12 @@ class getFileLogResource(Resource):
 
     @token_required
     def get(self, filename=None):
-        if not os.path.isfile("{}/{}.log".format(C.LOG_BASE, filename)):
+        # Construct the full path and normalize it
+        fullpath = os.path.normpath(os.path.join(C.LOG_BASE, f"{filename}.log"))
+        # Ensure the normalized path starts with the base directory
+        if not fullpath.startswith(C.LOG_BASE):
+            return exception("Invalid file path.", code=400)
+        if not os.path.isfile(fullpath):
             return exception("Cannot found that file log {}".format(filename), code=400)
         for args in request.args:
             if not args in self.args:
@@ -48,7 +53,7 @@ class getFileLogResource(Resource):
 
         table = []
         page = int(request.args.get("page"))
-        with open("{}/{}.log".format(C.LOG_BASE, filename), "r") as f:
+        with open(fullpath, "r") as f:
             for line in f:
                 table.append(json.loads(line))
         data_splited = list(self.chunk(table, self.limit_view))


### PR DESCRIPTION
Potential fix for [https://github.com/kimocoder/wifipumpkin3/security/code-scanning/1](https://github.com/kimocoder/wifipumpkin3/security/code-scanning/1)

To fix the issue, we need to validate and sanitize the `filename` parameter before using it to construct a file path. The best approach is to:
1. Normalize the constructed path using `os.path.normpath` to remove any `..` segments.
2. Ensure that the normalized path starts with the intended base directory (`C.LOG_BASE`).
3. Optionally, use a stricter validation mechanism, such as `werkzeug.utils.secure_filename`, to ensure the filename is safe and does not contain special characters.

The changes will be made in the `get` method of the `getFileLogResource` class. Specifically:
- Normalize the constructed path.
- Check that the normalized path starts with `C.LOG_BASE`.
- Raise an exception if the validation fails.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Enforce path normalization and base directory checks for log file retrieval to fix uncontrolled data usage in path expressions and mitigate directory traversal vulnerabilities.

Bug Fixes:
- Normalize and validate log file paths to prevent directory traversal.
- Restrict file access to the configured log base directory.
- Return a 400 error for invalid or non-existent log file requests.