### PR TITLE
Potential fix for code scanning alert no. 4: Binding a socket to all network interfaces

### DIFF
--- a/wifipumpkin3/core/packets/listener.py
+++ b/wifipumpkin3/core/packets/listener.py
@@ -291,7 +291,7 @@ str(p)
 if __name__ == "__main__":
     s1 = socket(type=SOCK_DGRAM)
     s1.setsockopt(SOL_IP, SO_REUSEADDR, 1)
-    s1.bind(("", 67))
+    s1.bind(("127.0.0.1", 67))  # Bind to the loopback address for local testing
     # s2 = socket(type = SOCK_DGRAM)
     # s2.setsockopt(SOL_IP, SO_REUSEADDR, 1)
     # s2.bind(('', 68))


### PR DESCRIPTION
Potential fix for [https://github.com/kimocoder/wifipumpkin3/security/code-scanning/4](https://github.com/kimocoder/wifipumpkin3/security/code-scanning/4)

To fix the issue, the socket should be bound to a specific IP address instead of all interfaces. This can be achieved by replacing the empty string `''` in `s1.bind(("", 67))` with a specific IP address, such as `127.0.0.1` (loopback address) for local testing or a dedicated interface's IP address for production use. This change ensures that the socket only listens for connections on the specified interface, reducing the attack surface.

The specific IP address to use depends on the intended use case:
- For local testing, use `127.0.0.1`.
- For production, replace it with the IP address of the interface that should handle the traffic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Change socket.bind from ('', 67) to ('127.0.0.1', 67) to mitigate code scanning alert about binding to all interfaces