### PR TITLE
Potential fix for code scanning alert no. 5: URL redirection from remote source

### DIFF
--- a/wifipumpkin3/plugins/bin/captiveflask.py
+++ b/wifipumpkin3/plugins/bin/captiveflask.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, redirect, render_template
+from urllib.parse import urlparse, unquote
 from urllib.parse import urlencode, unquote
 from wifipumpkin3.core.utility.collection import SettingsINI
 import wifipumpkin3.core.utility.constants as C
@@ -16,6 +17,21 @@ URL_REDIRECT = None
 PORT = 80
 config = None
 
+def is_safe_url(target):
+    """
+    Validates if the given URL is safe for redirection.
+    A URL is considered safe if it is relative or matches allowed domains.
+    """
+    allowed_domains = {"example.com", "another-safe-domain.com"}  # Add allowed domains here
+    target = target.replace('\\', '')  # Normalize backslashes
+    parsed = urlparse(target)
+    if not parsed.netloc and not parsed.scheme:
+        # Relative URL, safe to redirect
+        return True
+    if parsed.netloc in allowed_domains:
+        # Absolute URL with an allowed domain
+        return True
+    return False
 
 def login_user(ip, iptables_binary_path):
     subprocess.call(
@@ -49,7 +65,11 @@ def login():
         if FORCE_REDIRECT:
             return render_template("templates/login_successful.html")
         elif "orig_url" in request.args and len(request.args["orig_url"]) > 0:
-            return redirect(unquote(request.args["orig_url"]))
+            orig_url = unquote(request.args["orig_url"])
+            if is_safe_url(orig_url):
+                return redirect(orig_url)
+            else:
+                return redirect('/')
         else:
             return render_template("templates/login_successful.html")
     else:


### PR DESCRIPTION
Potential fix for [https://github.com/kimocoder/wifipumpkin3/security/code-scanning/5](https://github.com/kimocoder/wifipumpkin3/security/code-scanning/5)

To fix the issue, we will validate the `orig_url` parameter before using it in the `redirect` function. Specifically, we will ensure that the URL is either relative (safe for redirection) or matches a predefined list of allowed domains. This can be achieved using the `urlparse` function from Python's standard library to parse the URL and check its components.

Steps to fix:
1. Import the `urlparse` module if not already imported.
2. Replace the direct use of `unquote(request.args["orig_url"])` with a validation function that checks the safety of the URL.
3. If the URL is invalid or unsafe, redirect to a default safe page (e.g., the home page).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Validate redirect targets to prevent open redirect vulnerabilities by ensuring the orig_url parameter is either relative or on an allowed domain and falling back to a safe default page

Bug Fixes:
- Prevent unsafe URL redirection by validating orig_url and redirecting to the home page if it’s invalid or unsafe

Enhancements:
- Introduce is_safe_url helper to allow only relative URLs or specified whitelisted domains for redirects