### PR TITLE
Potential fix for code scanning alert no. 7: URL redirection from remote source

### DIFF
--- a/wifipumpkin3/plugins/bin/evilqr3.py
+++ b/wifipumpkin3/plugins/bin/evilqr3.py
@@ -55,7 +55,14 @@ def login():
         if FORCE_REDIRECT:
             return render_template("templates/login_successful.html")
         elif "orig_url" in request.args and len(request.args["orig_url"]) > 0:
-            return redirect(unquote(request.args["orig_url"]))
+            orig_url = unquote(request.args["orig_url"])
+            from urllib.parse import urlparse
+            orig_url = orig_url.replace('\\', '')  # Normalize backslashes
+            parsed_url = urlparse(orig_url)
+            if not parsed_url.netloc and not parsed_url.scheme:  # Ensure it's a relative URL
+                return redirect(orig_url)
+            else:
+                return redirect('/')  # Redirect to a safe default location
         else:
             return render_template("templates/login_successful.html")
     else:
@@ -92,7 +99,14 @@ def Mobilelogin():
         if FORCE_REDIRECT:
             return render_template("templates/login_successful.html")
         elif "orig_url" in request.args and len(request.args["orig_url"]) > 0:
-            return redirect(unquote(request.args["orig_url"]))
+            orig_url = unquote(request.args["orig_url"])
+            from urllib.parse import urlparse
+            orig_url = orig_url.replace('\\', '')  # Normalize backslashes
+            parsed_url = urlparse(orig_url)
+            if not parsed_url.netloc and not parsed_url.scheme:  # Ensure it's a relative URL
+                return redirect(orig_url)
+            else:
+                return redirect('/')  # Redirect to a safe default location
         else:
             return render_template("templates/login_successful.html")
     else:


### PR DESCRIPTION
Potential fix for [https://github.com/kimocoder/wifipumpkin3/security/code-scanning/7](https://github.com/kimocoder/wifipumpkin3/security/code-scanning/7)

To fix the issue, we need to validate the `orig_url` parameter before using it in a redirection. The best approach is to ensure that the URL is either relative (i.e., does not include a host name) or matches a predefined list of allowed URLs. This can be achieved using the `urlparse` function from Python's `urllib.parse` module to check the `netloc` and `scheme` attributes of the URL.

Specifically:
1. Replace the direct use of `unquote(request.args["orig_url"])` with a validation step.
2. If the URL is valid (e.g., relative or in an allowed list), proceed with the redirection.
3. If the URL is invalid, redirect to a safe default location (e.g., the home page).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Validate the `orig_url` parameter for login redirects to prevent open redirect vulnerabilities

Bug Fixes:
- Sanitize and parse `orig_url` in both `login()` and `Mobilelogin()` to allow only relative URLs
- Fallback to the home page for invalid or external URLs instead of redirecting to untrusted locations