### PR TITLE
Potential fix for code scanning alert no. 3: Binding a socket to all network interfaces

### DIFF
--- a/wifipumpkin3/core/packets/dhcpserver.py
+++ b/wifipumpkin3/core/packets/dhcpserver.py
@@ -1,4 +1,5 @@
 import socket
+import netifaces
 from dhcplib.packet import DHCPPacket, _FORMAT_CONVERSION_DESERIAL, DHCP_OPTIONS_TYPES
 import ipaddress as ip
 from queue import Queue
@@ -178,7 +179,9 @@ class DHCPThread(QThread):
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-        self.sock.bind(("", server_port))
+        import netifaces
+        iface_ip = netifaces.ifaddresses(self.iface)[netifaces.AF_INET][0]['addr']
+        self.sock.bind((iface_ip, server_port))
         self.sock.setsockopt(
             socket.SOL_SOCKET, socket.SO_BINDTODEVICE, str(self.iface + "\0").encode()
         )


### PR DESCRIPTION
Potential fix for [https://github.com/kimocoder/wifipumpkin3/security/code-scanning/3](https://github.com/kimocoder/wifipumpkin3/security/code-scanning/3)

To fix the issue, replace the `self.sock.bind(("", server_port))` line with a bind call that explicitly uses the IP address of the desired interface. The IP address can be retrieved dynamically using the `iface` parameter, which represents the network interface. This ensures that the socket is bound only to the specific interface, improving security and clarity.

The fix involves:
1. Importing the `netifaces` library to retrieve the IP address of the specified interface.
2. Replacing the `self.sock.bind(("", server_port))` line with a bind call that uses the retrieved IP address.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Restrict the DHCP server socket binding to the specified network interface IP to address a security alert.

Bug Fixes:
- Resolve code scanning alert by replacing the all-interfaces bind with a bind to the specific interface IP.

Enhancements:
- Add netifaces to dynamically obtain and use the interface’s IPv4 address for socket binding.